### PR TITLE
feat: Writing package.json separately

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,9 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      # Check for updates to npm dependencies every weekday
+      interval: "daily"

--- a/action.yaml
+++ b/action.yaml
@@ -26,14 +26,11 @@ runs:
       PROJECT_NAME: ${{ inputs.PROJECT_NAME }}
       RELEASE_BRANCH: ${{ inputs.RELEASE_BRANCH }}
     run: |
-      echo '{
-        "name": "'${PROJECT_NAME}'",
-        "private": true,
-        "devDependencies": {
-          "@semantic-release/github": "^9.0.3",
-          "semantic-release": "^21.0.5"
-        }
-      }' >> package.json
+      # Copy the package.json file from the action to the current directory
+      cp ${{ github.action_path}}/package.json .
+      
+      # Update the package.json file with the project name
+      sed -i "s/PROJECT_NAME/${PROJECT_NAME}/g" package.json
       
       echo -e '{
         "name": "'${PROJECT_NAME}'",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "PROJECT_NAME",
+  "private": true,
+  "devDependencies": {
+    "@semantic-release/github": "^9.0.3",
+    "semantic-release": "^21.0.5"
+  }
+}


### PR DESCRIPTION
Moved package.json into project directory and updated action to replace PROJECT_NAME with the project name. 

The idea is that Dependabot can be used to ensure the action is always using a secure/recent version of the semantic-release packages.

Additionally updated Dependabot config to include npm