### PR TITLE
feat: Release major versions, add outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_ACTION_DOCS -->
 
 # github-actions-releaser
-Release GitHub actions versions
+Release GitHub actions versions, including rolling major versions.
 
 # inputs
 | Title | Required | Type | Description |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Release GitHub actions versions
 | PROJECT_NAME | True |  | The name of the project to be released |
 | GITHUB_TOKEN | True |  | The file that the output report will be written to |
 | RELEASE_BRANCH | True |  | The branch to release from |
+
+# outputs
+| Title | Description | Value |
+|-----|-----|-----|
+|NEW_RELEASE | The new release version |  `${{ steps.Release.outputs.NEW_RELEASE }}` | 
+|NEW_MAJOR_RELEASE | The new major release version |  `${{ steps.Release.outputs.NEW_MAJOR_RELEASE }}` | 
 <!-- END_ACTION_DOCS -->
 
 # Example usage

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: "github-actions-releaser"
-description: "Release GitHub actions versions"
+description: "Release GitHub actions versions, including rolling major versions."
 branding:
   color: "green"
   icon: "book-open"

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,13 @@ inputs:
     description: "The branch to release from"
     required: true
     default: "main"
+outputs:
+  NEW_RELEASE:
+    description: "The new release version"
+    value: ${{ steps.Release.outputs.NEW_RELEASE }}
+  NEW_MAJOR_RELEASE:
+    description: "The new major release version"
+    value: ${{ steps.Release.outputs.NEW_MAJOR_RELEASE }}
 runs:
   using: "composite"
   steps:
@@ -54,6 +61,30 @@ runs:
     shell: bash
     env:
       GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
     run: |
       cd "${GITHUB_SHA}"
       npx semantic-release
+
+      # Get new release version
+      new_release=$(gh release list --limit 1 --json tagName | jq -r '.[0].tagName')
+      new_major_release=$(echo $new_release | cut -d. -f1)
+
+      ## Release major version
+      # Delete major version if it exists (don't fail if it doesn't)
+      git push origin --delete $new_major_release || true
+      gh release delete $new_major_release || true
+
+      # Create major version
+      git tag -f $new_major_release
+      git push origin --tags
+
+      # Recreate release
+      gh release create $new_major_release --generate-notes
+
+      echo "New release version: $new_release"
+      echo "New major release version: $new_major_release"
+
+      # Create outputs
+      echo "NEW_RELEASE=$new_release" >> $GITHUB_OUTPUT
+      echo "NEW_MAJOR_RELEASE=$new_major_release" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request to `action.yaml` includes changes to add new outputs and update the release process. The most important changes include adding new outputs for the release versions and updating the release steps to handle major version releases.

### Outputs Addition:
* Added new outputs `NEW_RELEASE` and `NEW_MAJOR_RELEASE` to capture the new release version and the new major release version respectively. (`[action.yamlR17-R23](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR17-R23)`)

### Release Process Update:
* Updated the release steps to include setting the `GH_TOKEN` environment variable, obtaining the new release version, handling the major version release, and creating outputs for the new release versions. (`[action.yamlR64-R90](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR64-R90)`)