### PR TITLE
fix: Fixed value for outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Release GitHub actions versions, including rolling major versions.
 # outputs
 | Title | Description | Value |
 |-----|-----|-----|
-|NEW_RELEASE | The new release version |  `${{ steps.Release.outputs.NEW_RELEASE }}` | 
-|NEW_MAJOR_RELEASE | The new major release version |  `${{ steps.Release.outputs.NEW_MAJOR_RELEASE }}` | 
+|NEW_RELEASE | The new release version |  `${{ steps.release.outputs.NEW_RELEASE }}` | 
+|NEW_MAJOR_RELEASE | The new major release version |  `${{ steps.release.outputs.NEW_MAJOR_RELEASE }}` | 
 <!-- END_ACTION_DOCS -->
 
 # Example usage

--- a/action.yaml
+++ b/action.yaml
@@ -17,10 +17,10 @@ inputs:
 outputs:
   NEW_RELEASE:
     description: "The new release version"
-    value: ${{ steps.Release.outputs.NEW_RELEASE }}
+    value: ${{ steps.release.outputs.NEW_RELEASE }}
   NEW_MAJOR_RELEASE:
     description: "The new major release version"
-    value: ${{ steps.Release.outputs.NEW_MAJOR_RELEASE }}
+    value: ${{ steps.release.outputs.NEW_MAJOR_RELEASE }}
 runs:
   using: "composite"
   steps:
@@ -59,6 +59,7 @@ runs:
 
   - name: Release
     shell: bash
+    id: release
     env:
       GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a few changes to the `action.yaml` file, specifically in the `outputs` and `runs` sections. The changes correct the case sensitivity of step IDs and add an ID to a step.

* Corrected the case sensitivity of step IDs in the `outputs` section (`steps.Release` to `steps.release`).
* Added an ID (`release`) to the `Release` step in the `runs` section.